### PR TITLE
Add test grid scenario for Artemis connector

### DIFF
--- a/.testgrid-artemis.yaml
+++ b/.testgrid-artemis.yaml
@@ -1,0 +1,64 @@
+# Copyright (c) 2019, WSO2 Inc. (http://wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# TestGrid Test Configuration Parameters
+version: '0.9'
+emailToList: "riyafa@wso2.com,builder@wso2.org"
+infrastructureConfig:
+  infrastructureProvider: SHELL
+  containerOrchestrationEngine: K8S
+  includes:
+    - Ubuntu-18.04
+    - OracleJDK-8
+  provisioners:
+  - name: ballerina-deployment
+    remoteRepository: "https://github.com/ballerina-platform/ballerina-scenario-tests.git"
+    remoteBranch: "master"
+    description: creates infrastructure for ballerina scenario tests
+    scripts:
+      - name: ballerina-deployment
+        description: Creates Kubernetes infrastructure for a ballerina installed instance.
+        type: SHELL
+        phase: CREATE
+        file: test-grid-scripts/common/common_infra.sh
+      - name: destroy
+        file: test-grid-scripts/common/common_cleanup.sh
+        type: SHELL
+        phase: DESTROY
+deploymentConfig:
+  deploymentPatterns:
+    - name: 'dual-channel-with-artemis-connector'
+      description: 'artemis-scenario-tests'
+      remoteRepository: "https://github.com/ballerina-platform/ballerina-scenario-tests.git"
+      remoteBranch: "master"
+      dir: .
+      scripts:
+        - name: 'default'
+          type: SHELL
+          file: test-grid-scripts/connectors/artemis/deployment-artemis-connector.sh
+          inputParameters:
+            BallerinaVersionType: "LatestSnapshot"
+            isDebugEnabled: "true"
+            TestGroup: "ArtemisConnector"
+scenarioConfigs:
+- testType: TESTNG
+  remoteRepository: "https://github.com/ballerina-platform/ballerina-scenario-tests.git"
+  remoteBranch: "master"
+  name: "ballerinaScenarios"
+  description: "artemis-scenario-tests"
+  file: test-grid-scripts/connectors/artemis/artemis-test-runner.sh
+  inputParameters:
+    isDebugEnabled: "true"

--- a/connectors/artemis/pom.xml
+++ b/connectors/artemis/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+
+WSO2 Inc. licenses this file to you under the Apache License,
+Version 2.0 (the "License"); you may not use this file except
+in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.ballerinalang</groupId>
+        <artifactId>ballerina-scenario-test</artifactId>
+        <version>0.990.4-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>artemis-tests</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.ballerinalang</groupId>
+            <artifactId>ballerina-scenario-test-commons</artifactId>
+            <scope>test</scope>
+            <version>${ballerina.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.plugin.version}</version>
+                <configuration>
+                    <suiteXmlFiles>
+                        <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
+                    </suiteXmlFiles>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/connectors/artemis/src/test/java/org/ballerinalang/scenario/test/connector/artemis/ArtemisTest.java
+++ b/connectors/artemis/src/test/java/org/ballerinalang/scenario/test/connector/artemis/ArtemisTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.ballerinalang.scenario.test.connector.artemis;
+
+import org.ballerinalang.scenario.test.common.ScenarioTestBase;
+import org.ballerinalang.scenario.test.common.http.HttpClientRequest;
+import org.ballerinalang.scenario.test.common.http.HttpResponse;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * This tests the dual channel scenario using Artemis connector.
+ */
+@Test(groups = "ArtemisConnector")
+public class ArtemisTest extends ScenarioTestBase {
+    private static String host;
+    private static String port;
+
+    static {
+        Properties deploymentProperties = getDeploymentProperties();
+        host = deploymentProperties.getProperty("ExternalIP");
+        port = deploymentProperties.getProperty("NodePort");
+    }
+
+    @Test(description = "Test Artemis connector")
+    public void testArtemisConnector() throws IOException {
+        String url = "http://" + host + ":" + port + "/artemis/test";
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Content-Type", "application/json");
+        HttpResponse httpResponse = HttpClientRequest.doPost(url, "{\"Hi\":\"World\"}", headers);
+        Assert.assertEquals(httpResponse.getResponseCode(), 200, "Response code mismatching");
+        Assert.assertEquals(httpResponse.getData(), "{\"hello\":\"Riyafa\"}");
+    }
+}

--- a/connectors/artemis/src/test/resources/artemis-deployment.yaml
+++ b/connectors/artemis/src/test/resources/artemis-deployment.yaml
@@ -1,0 +1,41 @@
+# Copyright (c) 2019, WSO2 Inc. (http://wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+    name: artemis-broker
+    labels:
+        app: artemis
+spec:
+    replicas: 1
+    strategy:
+        type: Recreate
+    selector:
+        matchLabels:
+            app: artemis
+    template:
+        metadata:
+            labels:
+                app: artemis
+        spec:
+            containers:
+                - name: artemis
+                  image: vromero/activemq-artemis:2.7.0
+                  imagePullPolicy: IfNotPresent
+                  ports:
+                      - containerPort: 61616
+                        name: artemis

--- a/connectors/artemis/src/test/resources/artemis-service.yaml
+++ b/connectors/artemis/src/test/resources/artemis-service.yaml
@@ -1,0 +1,26 @@
+# Copyright (c) 2019, WSO2 Inc. (http://wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+    name: artemis-broker
+spec:
+    selector:
+        app: artemis
+    ports:
+        - protocol: TCP
+          port: 61616

--- a/connectors/artemis/src/test/resources/dual-channel-scenario/consumer.bal
+++ b/connectors/artemis/src/test/resources/dual-channel-scenario/consumer.bal
@@ -1,0 +1,76 @@
+// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/artemis;
+import ballerina/filepath;
+import ballerina/http;
+import ballerinax/kubernetes;
+
+artemis:Connection con = new("tcp://artemis-broker:61616");
+artemis:Session session = new(con, config = {username: "artemis", password: "simetraehcapa"});
+
+@kubernetes:Ingress {
+    hostname:"artemis.ballerina.io",
+    name:"artemis-consumer",
+    path:"/"
+}
+
+@kubernetes:Service {
+    serviceType:"NodePort",
+    name:"artemis-consumer",
+    port: 8888,
+    targetPort: 8888
+}
+
+@kubernetes:Deployment {
+    image:"artemis.ballerina.io/artemis-consumer:v1.0",
+    name:"artemis-consumer",
+    username:"<USERNAME>",
+    password:"<PASSWORD>",
+    push:true,
+    imagePullPolicy:"Always"
+}
+listener artemis:Listener consumerListener = new(session);
+@artemis:ServiceConfig {
+    queueConfig: {
+        queueName: "SMSStore"
+    }
+}
+service artemisConsumer on consumerListener {
+
+    resource function onMessage(artemis:Message message) returns error? {
+        artemis:MessageConfiguration config = message.getConfig();
+        var replyTo = config.replyTo;
+
+        http:Client remoteClient = new("http://http-service:9090");
+        var payload = message.getPayload();
+        if (payload is string) {
+            var response = remoteClient->post("/remote", untaint payload);
+            if (response is http:Response) {
+                if (replyTo is string) {
+                    artemis:Producer forwardProd = new(session, replyTo);
+                    var uuid = message.getProperty("UUID");
+                    if (uuid is string) {
+                        artemis:Message msg = new(session, untaint check response.getJsonPayload(), 
+                    config={correlationId: uuid});
+                        check forwardProd->send(untaint msg);
+                    }
+                }
+
+            }
+        }
+    }
+}

--- a/connectors/artemis/src/test/resources/dual-channel-scenario/remote.bal
+++ b/connectors/artemis/src/test/resources/dual-channel-scenario/remote.bal
@@ -1,0 +1,59 @@
+// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/log;
+import ballerinax/kubernetes;
+
+@kubernetes:Ingress {
+    hostname:"artemis.ballerina.io",
+    name:"http-service",
+    path:"/"
+}
+
+@kubernetes:Service {
+    serviceType:"NodePort",
+    name:"http-service"
+}
+
+@kubernetes:Deployment {
+    image:"artemis.ballerina.io/http-service:v1.0",
+    name:"http-service",
+    username:"<USERNAME>",
+    password:"<PASSWORD>",
+    push:true,
+    imagePullPolicy:"Always"
+}
+
+listener http:Listener helloListener = new(9090);
+@http:ServiceConfig {
+    basePath: "/"
+}
+service hello on helloListener {
+
+    @http:ResourceConfig {
+        path: "/remote",
+        methods: ["POST"]
+    }
+    resource function sayHello(http:Caller caller, http:Request req) {
+        json resp = {"hello": "Riyafa"};
+        var result = caller->respond(resp);
+
+        if (result is error) {
+            log:printError("Error sending response", err = result);
+        }
+    }
+}

--- a/connectors/artemis/src/test/resources/dual-channel-scenario/sender.bal
+++ b/connectors/artemis/src/test/resources/dual-channel-scenario/sender.bal
@@ -1,0 +1,77 @@
+// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/artemis;
+import ballerina/filepath;
+import ballerina/http;
+import ballerina/system;
+import ballerinax/kubernetes;
+
+artemis:Connection con = new("tcp://artemis-broker:61616");
+artemis:Session session = new(con, config = {username: "artemis", password: "simetraehcapa"});
+
+@kubernetes:Ingress {
+    hostname:"artemis.ballerina.io",
+    name:"artemis-sender",
+    path:"/"
+}
+
+@kubernetes:Service {
+    serviceType:"NodePort",
+    name:"artemis-sender"
+}
+
+@kubernetes:Deployment {
+    image:"artemis.ballerina.io/artemis-sender:v1.0",
+    name:"artemis-sender",
+    username:"<USERNAME>",
+    password:"<PASSWORD>",
+    push:true,
+    imagePullPolicy:"Always"
+}
+
+listener http:Listener sendListener = new(8080);
+
+@http:ServiceConfig {
+    basePath: "/artemis"
+}
+service SMSSenderProxy on sendListener {
+    @http:ResourceConfig {
+        path: "/test",
+        methods: ["POST"]
+    }
+    resource function send(http:Caller caller, http:Request request) returns error? {
+        artemis:Producer forwardProd = new(session, "SMSStore");
+
+        artemis:Message msg = new(session, untaint check request.getJsonPayload(), 
+        config = {replyTo: "SMSReceiveNotificationStore"});
+        string id = system:uuid();
+        msg.putProperty("UUID", id);
+        check forwardProd->send(msg);
+
+        string filter = "JMSCorrelationID = '" + id + "'";
+        artemis:Listener qListener = new(session);
+        artemis:Consumer consumer = check qListener.createAndGetConsumer({
+            queueName: "SMSReceiveNotificationStore"
+        }, autoAck = true, filter = filter);
+
+        msg = check consumer->receive(timeoutInMilliSeconds = 3000);
+        var payload = msg.getPayload();
+        if (payload is json) {
+            check caller->respond(untaint payload);
+        }
+    }
+}

--- a/connectors/artemis/src/test/resources/testng.xml
+++ b/connectors/artemis/src/test/resources/testng.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+
+WSO2 Inc. licenses this file to you under the Apache License,
+Version 2.0 (the "License"); you may not use this file except
+in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="ballerina-artemis-connector-test-suite">
+    <test name="ballerina-artemis-connector-test-suite" parallel="false">
+        <packages>
+            <package name="org.ballerinalang.scenario.test.connector.artemis.*"/>
+        </packages>
+    </test>
+</suite>

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,7 @@
                 <module>bbg/kafka</module>
                 <module>bbg/bbg-integration-patterns</module>
                 <module>connectors/soap</module>
+                <module>connectors/artemis</module>
             </modules>
         </profile>
         <profile>
@@ -113,6 +114,13 @@
             <modules>
                 <module>scenarios-commons</module>
                 <module>connectors/soap</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>messaging-artemis</id>
+            <modules>
+                <module>scenarios-commons</module>
+                <module>connectors/artemis</module>
             </modules>
         </profile>
         <profile>

--- a/test-grid-scripts/connectors/artemis/artemis-test-runner.sh
+++ b/test-grid-scripts/connectors/artemis/artemis-test-runner.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Copyright (c) 2019, WSO2 Inc. (http://wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+readonly test_artemis_parent_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+readonly test_artemis_grand_parent_path=$(dirname ${test_artemis_parent_path})
+readonly test_artemis_great_grand_parent_path=$(dirname ${test_artemis_grand_parent_path})
+readonly test_artemis_great_great_grand_parent_path=$(dirname ${test_artemis_great_grand_parent_path})
+
+. ${test_artemis_great_grand_parent_path}/common/usage.sh
+. ${test_artemis_great_grand_parent_path}/setup/setup_test_env.sh
+
+run_provided_test() {
+    local test_group_to_run=${deployment_config["TestGroup"]}
+
+    if [ "${test_group_to_run}" = "ArtemisConnector" ]; then
+        . ${test_artemis_parent_path}/test-artemis-connector.sh
+    fi
+}
+
+run_provided_test

--- a/test-grid-scripts/connectors/artemis/deployment-artemis-connector.sh
+++ b/test-grid-scripts/connectors/artemis/deployment-artemis-connector.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# Copyright (c) 2019, WSO2 Inc. (http://wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+readonly deployment_artemis_parent_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+readonly deployment_artemis_grand_parent_path=$(dirname ${deployment_artemis_parent_path})
+readonly deployment_artemis_great_grand_parent_path=$(dirname ${deployment_artemis_grand_parent_path})
+
+. ${deployment_artemis_great_grand_parent_path}/common/usage.sh
+. ${deployment_artemis_great_grand_parent_path}/setup/setup_deployment_env.sh
+
+function setup_deployment() {
+    clone_repo_and_set_bal_path
+    deploy_artemis_broker
+    replace_variables_in_bal_files
+    build_and_deploy_artemis_resources
+    wait_for_pod_readiness
+    retrieve_and_write_properties_to_data_bucket
+    local is_debug_enabled=${infra_config["isDebugEnabled"]}
+    if [ "${is_debug_enabled}" = "true" ]; then
+        print_kubernetes_debug_info
+    fi
+}
+
+## Functions
+
+function clone_repo_and_set_bal_path() {
+    git clone https://github.com/ballerina-platform/ballerina-scenario-tests.git
+    consumer_bal_path=connectors/artemis/src/test/resources/dual-channel-scenario/consumer.bal
+    remote_bal_path=connectors/artemis/src/test/resources/dual-channel-scenario/remote.bal
+    sender_bal_path=connectors/artemis/src/test/resources/dual-channel-scenario/sender.bal
+}
+
+function deploy_artemis_broker() {
+    docker login --username=${docker_user} --password=${docker_password}
+
+    kubectl create -f connectors/artemis/src/test/resources/artemis-deployment.yaml
+    kubectl create -f connectors/artemis/src/test/resources/artemis-service.yaml
+    wait_for_pod_readiness
+    kubectl get svc
+}
+
+function print_kubernetes_debug_info() {
+    kubectl get pods
+    kubectl get svc artemis-sender -o=json
+    kubectl get svc http-service -o=json
+    kubectl get svc artemis-consumer -o=json
+    kubectl get nodes --output wide
+}
+
+function replace_variables_in_bal_files() {
+    replace_variables_in_bal_file ${consumer_bal_path}
+    replace_variables_in_bal_file ${remote_bal_path}
+    replace_variables_in_bal_file ${sender_bal_path}
+}
+
+function replace_variables_in_bal_file() {
+    local bal_path=$1
+    sed -i "s:<USERNAME>:${docker_user}:g" ${bal_path}
+    sed -i "s:<PASSWORD>:${docker_password}:g" ${bal_path}
+    sed -i "s:artemis.ballerina.io:${docker_user}:g" ${bal_path}
+}
+
+function build_and_deploy_artemis_resources() {
+    cd connectors/artemis/src/test/resources/dual-channel-scenario
+    ${ballerina_home}/bin/ballerina init
+    ${ballerina_home}/bin/ballerina build
+    cd ../../../../../..
+    kubectl apply -f ${work_dir}/connectors/artemis/src/test/resources/dual-channel-scenario/target/kubernetes/consumer --namespace=${cluster_namespace}
+    kubectl apply -f ${work_dir}/connectors/artemis/src/test/resources/dual-channel-scenario/target/kubernetes/remote --namespace=${cluster_namespace}
+    kubectl apply -f ${work_dir}/connectors/artemis/src/test/resources/dual-channel-scenario/target/kubernetes/sender --namespace=${cluster_namespace}
+}
+
+function retrieve_and_write_properties_to_data_bucket() {
+    local external_ip=$(kubectl get nodes -o=jsonpath='{.items[0].status.addresses[?(@.type=="ExternalIP")].address}')
+    local node_port=$(kubectl get svc artemis-sender -o=jsonpath='{.spec.ports[0].nodePort}')
+    declare -A deployment_props
+    deployment_props["ExternalIP"]=${external_ip}
+    deployment_props["NodePort"]=${node_port}
+    write_to_properties_file ${output_dir}/deployment.properties deployment_props
+    local is_debug_enabled=${infra_config["isDebugEnabled"]}
+    if [ "${is_debug_enabled}" = "true" ]; then
+        echo "ExternalIP: ${external_ip}"
+        echo "NodePort: ${node_port}"
+    fi
+}
+
+setup_deployment

--- a/test-grid-scripts/connectors/artemis/test-artemis-connector.sh
+++ b/test-grid-scripts/connectors/artemis/test-artemis-connector.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Copyright (c) 2019, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function print_debug_info() {
+    echo "Host And Port: ${external_ip}:${node_port}"
+}
+
+function run_tests() {
+    local external_ip=${deployment_config["ExternalIP"]}
+    local node_port=${deployment_config["NodePort"]}
+
+    local is_debug_enabled=${deployment_config["isDebugEnabled"]}
+    if [ "${is_debug_enabled}" = "true" ]; then
+        print_debug_info
+    fi
+
+    declare -A sys_prop_array
+    sys_prop_array["artemis.service.host"]=${external_ip}
+    sys_prop_array["artemis.service.port"]=${node_port}
+
+    # Builds and run tests of the given connector section and copies resulting surefire reports to output directory
+    run_connector_section_tests artemis artemis sys_prop_array ${input_dir} ${output_dir} "ArtemisConnector"
+}
+
+run_tests


### PR DESCRIPTION
## Purpose
> Add dual channel scenario for the Artemis connector
https://docs.wso2.com/display/ESB490/JMS+Synchronous+Invocations+%3A+Dual+Channel+HTTP-to-JMS

## Goals
> Add scenario test

## Approach
> Adds a scenario test with the necessary scripts and test cases

## User stories
> One HTTP service that sends the received message to a queue. A consumer listening to the queue passes this message to a backend service. Once a response is received from the backend service it is delivered to a replyTo queue. The first service receives this from the replyTo queue and responds to the requester.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > This is a scenario test as described above

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
>  - Ubuntu-18.04
    - OracleJDK-8
 
## Learning
> https://github.com/ballerina-platform/ballerina-scenario-tests/pull/26